### PR TITLE
add-header-and-footer-view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,4 +4,6 @@
 @import "modules/transaction";
 @import "modules/header-sub";
 @import "modules/footer-sub";
+@import "modules/footer-main";
+@import "modules/header-main";
 

--- a/app/assets/stylesheets/modules/_footer-main.scss
+++ b/app/assets/stylesheets/modules/_footer-main.scss
@@ -1,0 +1,34 @@
+.footer {
+  padding: 60px 0;
+  background-color: #272727;
+  color: #fff;
+  text-decoration: none;
+  text-align: center;
+  &__contents {
+    max-width: 840px;
+    margin: 0 auto;
+    display: flex;
+  }
+}
+.content {
+  width: calc(1 / 3 * 100%);
+  margin: 0 2% 0 0;
+  color:#fff;
+  display: flex;
+  flex-direction: column;
+  &__content-head{
+    margin: 0 0 20px;
+    font-size: 16px;
+    font-weight: bold;
+  }
+  &__content-lists {
+    margin-bottom: 20px;
+    font-size: 12px;
+    li{
+      height: 32px;
+    }
+  }
+}
+.footer-copy{
+  font-size:14px;
+}

--- a/app/assets/stylesheets/modules/_header-main.scss
+++ b/app/assets/stylesheets/modules/_header-main.scss
@@ -1,0 +1,75 @@
+.header-pc {
+  padding: 0 60px;
+  &__header-inner {
+    max-width: 1020px;
+    width: 100%;
+    min-height: 82px;
+    margin: 0 auto;
+    padding: 15px 0 0;
+  }
+}
+.header-main {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: 10px;
+  &__icon {
+    width: 140px;
+    height: 50.55px;
+    margin-right: 30px;
+    border-radius: 4px;
+  }
+  &__search-box {
+    width: 100%;
+    height: 41px;
+    margin-left: auto;
+  }
+}
+.search-inner {
+  width: 100%;
+  display: flex;
+  &__search-input {
+    width: calc(100% - 26px);
+    height: 36px;
+  }
+  &__submit-btn {
+    width: 40px;
+    height: 40px;
+    padding: 8px;
+    border: 0;
+    background-color: #3CCACE;
+    cursor: pointer;
+  }
+}
+.header-nav {
+  margin-bottom: 10px;
+  font-size: 14px;
+  display: flex;
+  &__lists-left {
+    width: 200px;
+    height: 30px;
+    display: flex;
+  }
+  &__lists-right {
+    height: 30px;
+    margin-left: auto;
+    display: flex;
+  }
+}
+ul,ol{
+  list-style: none;
+}
+#catBtn, #brandBtn {
+  padding-right: 30px;
+  text-decoration: none;
+}
+#loginBtn, #signupBtn {
+  padding-left:16px;
+  text-decoration: none;
+}
+a:active {
+  color: #000000;
+}
+a {
+  color: #000000;
+}

--- a/app/views/layouts/_footer-main.html.haml
+++ b/app/views/layouts/_footer-main.html.haml
@@ -1,0 +1,39 @@
+.footer
+  %ul.footer__contents
+    %li.content
+      %h2.content__content-head
+        FURIMAについて
+      %ul.content__content-lists
+        %li.content__content-lists__content-list
+          会社概要 (運営会社)
+        %li.content__content-lists__content-list
+          プライバシーポリシー
+        %li.content__content-lists__content-list
+          FURIMA利用規約
+        %li.content__content-lists__content-list
+          ポイントに関する特約
+    %li.content
+      %h2.content__content-head
+        FURIMAを見る
+      %ul.content__content-lists
+        %li.content__content-lists__content-list
+          カテゴリー一覧
+        %li.content__content-lists__content-list
+          ブランド一覧
+    %li.content
+      %h2.content__content-head
+        ヘルプ&ガイド
+      %ul.content__content-lists
+        %li.content__content-lists__content-list
+          会社概要 (運営会社)
+        %li.content__content-lists__content-list
+          プライバシーポリシー
+        %li.content__content-lists__content-list
+          FURIMA利用規約
+        %li.content__content-lists__content-list
+          ポイントに関する特約
+  .footer-logo
+    %a{:href => '/'}
+      = image_tag 'logo/logo-white.png', :size => '160x47'
+    %p.footer-copy
+      ©FURIMA

--- a/app/views/layouts/_header-main.html.haml
+++ b/app/views/layouts/_header-main.html.haml
@@ -1,0 +1,50 @@
+.header-pc
+  .header-pc__header-inner
+    .header-main
+      .header-main__icon
+        %a{ :href => '/'}
+          = image_tag 'logo/logo.png', :size => '140x41'
+      .header-main__search-box
+        %form.search-inner
+          %input.search-inner__search-input{:placeholder => 'キーワードから探す'}
+          %button{type: "submit", class:'search-inner__submit-btn'}
+            .search-inner__submit-btn__icon
+              = image_tag 'icon/icon-search 1.png', :size => '20x20'
+    - if user_signed_in?
+      .header-nav
+        %ul.header-nav__lists-left
+          %li
+            %a{:href => '#', id: 'catBtn'}
+              カテゴリー
+          %li
+            %a{:href => '#', id: 'brandBtn'}
+              ブランド
+        %ul.header-nav__lists-right
+          %li
+            %a{:href => '#', id: 'loginBtn'}
+              いいね一覧
+          %li
+            %a{:href => '#', id: 'signupBtn'}
+              お知らせ
+          %li
+            %a{:href => '#', id: 'signupBtn'}
+              やることリスト
+          %li
+            %a{:href => '#', id: 'signupBtn'}
+              マイページ
+    - else
+      .header-nav
+        %ul.header-nav__lists-left
+          %li
+            %a{:href => '#', id: 'catBtn'}
+              カテゴリー
+          %li
+            %a{:href => '#', id: 'brandBtn'}
+              ブランド
+        %ul.header-nav__lists-right
+          %li
+            %a{:href => '#', id: 'loginBtn'}
+              ログイン
+          %li
+            %a{:href => '#', id: 'signupBtn'}
+              新規会員登録


### PR DESCRIPTION
# what
ヘッダーとフッター画面の実装
各画面から呼び出せるよう部分テンプレートとして作成し、view/layoutsフォルダに保存しています。
ログイン・未ログイン時でのヘッダーの表示項目の違いについては
user_signed_in?メソッドを使って実装しました

# why
ヘッダー・フッター画面は必須であるため
ログイン・未ログイン時では表示項目が異なるため