### PR TITLE
add-link-to-SignUp-and-SignIn

### DIFF
--- a/app/views/layouts/_header-main.html.haml
+++ b/app/views/layouts/_header-main.html.haml
@@ -43,8 +43,8 @@
               ブランド
         %ul.header-nav__lists-right
           %li
-            %a{:href => '#', id: 'loginBtn'}
+            = link_to new_user_session_path, id: "loginBtn" do
               ログイン
           %li
-            %a{:href => '#', id: 'signupBtn'}
+            = link_to new_user_registration_path, id: "signupBtn" do
               新規会員登録


### PR DESCRIPTION
# what
ヘッダーにログインと新規登録画面へのリンクを貼りました
link_toメソッドを使用しています
動作確認済みです

# why
未ログイン時ではログインか新規登録画面へのリンクが必要なため