### PR TITLE
create-address-table

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,5 @@
+class Address < ApplicationRecord
+  belongs_to :user
+  validates :postal_code, :prefectures, :ctiy, :block_number,presence: true
+  validates :postal_code,format: {with: /\A\d{3}[_]\d{4}\z/}
+end

--- a/db/migrate/20200623214527_create_addresses.rb
+++ b/db/migrate/20200623214527_create_addresses.rb
@@ -1,0 +1,13 @@
+class CreateAddresses < ActiveRecord::Migration[5.0]
+  def change
+    create_table :addresses do |t|
+      t.string     :postal_code,   null: false, limit: 7
+      t.string     :prefectures,   null: false
+      t.string     :ctiy,          null: false
+      t.string     :block_number,  null: false
+      t.string     :apartment_name
+      t.references :user,          null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200623113601) do
+ActiveRecord::Schema.define(version: 20200623214527) do
+
+  create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.string   "postal_code",    limit: 7, null: false
+    t.string   "prefectures",              null: false
+    t.string   "ctiy",                     null: false
+    t.string   "block_number",             null: false
+    t.string   "apartment_name"
+    t.integer  "user_id",                  null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.index ["user_id"], name: "index_addresses_on_user_id", using: :btree
+  end
 
   create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "name",       null: false
@@ -57,6 +69,7 @@ ActiveRecord::Schema.define(version: 20200623113601) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "addresses", "users"
   add_foreign_key "images", "items"
   add_foreign_key "items", "categories"
 end

--- a/test/fixtures/addresses.yml
+++ b/test/fixtures/addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/address_test.rb
+++ b/test/models/address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
addressテーブルの作成
各カラムの内容はREADMEを参照
各種バリデーションもモデルに記載しました
カラム名、型、オプションの設定がうまくいっているかはsequel.proで確認済みです

# why
商品出品や購入時に住所登録が必要なため