### PR TITLE
add-address-registration-view

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,7 +10,7 @@
 @import "modules/show";
 @import "modules/signin";
 @import "modules/signup";
-
+@import "modules/new_address";
 
 @import "items.new"
 

--- a/app/assets/stylesheets/modules/_new_address.scss
+++ b/app/assets/stylesheets/modules/_new_address.scss
@@ -1,0 +1,215 @@
+///mixin///
+@mixin flex {
+  display: flex;
+  align-items: center;
+}
+
+@mixin required {
+  background-color: #ff0000;
+  margin-left: 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+@mixin any {
+  background: #ccc;
+  margin: 0 0 0 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  vertical-align: top;
+}
+
+@mixin inner {
+  max-width: 343px;
+  margin: 0 auto;
+}
+
+@mixin input {
+  width: 100%;
+  margin-top: 8px;
+  height: 48px;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  line-height: 1.5;
+  font-size: 16px;
+}
+
+///main///
+.container{
+  padding-top: 24px;
+}
+.address{
+  width: 90%;
+  margin: 0 auto;
+  &__top{
+    p{
+      font-size: 24px;
+      font-weight: bold;
+    }
+    background-color: #fff;
+    text-align: center;
+    margin-bottom: 10px;
+    padding: 8px 24px;
+  }
+  &__inner{
+    background-color: #fff;
+    padding: 24px 16px 40px;
+    &__name{
+      @include inner;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--required{
+          @include required();
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__kana{
+      @include inner;
+      margin-top: 24px;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--required{
+          @include required();
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__ZipCode{
+      @include inner;
+      margin-top: 24px;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--required{
+          @include required();
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__prefectures{
+      @include inner;
+      margin-top: 24px;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--required{
+          @include required();
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__city{
+      @include inner;
+      margin-top: 24px;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--required{
+          @include required();
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__BlockNumber{
+      @include inner;
+      margin-top: 24px;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--required{
+          @include required();
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__apartment{
+      @include inner;
+      margin-top: 24px;
+      &__top{
+        @include flex;
+        p{
+          font-weight: bold;
+        }
+        &--any{
+          @include any;
+        }
+      }
+      &__form{
+        input{
+          @include input;
+        }
+      }
+    }
+
+    &__btn{
+      margin: 0 auto;
+      margin-top: 24px;
+      background: #ea352d;
+      border: 1px solid #ea352d;
+      color: #fff;
+      max-width: 343px;
+      line-height: 48px;
+      font-size: 14px;
+      border-radius: 4px;
+      border: 1px solid transparent;
+      -webkit-transition: all ease-out .3s;
+      transition: all ease-out .3s;
+      cursor: pointer;
+      text-align: center;
+    }
+
+   
+  }
+}

--- a/app/views/users/_new_address.html.haml
+++ b/app/views/users/_new_address.html.haml
@@ -1,0 +1,61 @@
+.container
+  .address
+    .address__top
+      %P 発送元・お届け先住所登録
+    .address__inner
+      .address__inner__name
+        .address__inner__name__top
+          %p.address__inner__name__top--title お名前
+          %p.address__inner__name__top--required 必須
+        .address__inner__name__form
+          %input(type="text" placeholder="例) 山田")/
+          %input(type="text" placeholder="例) 彩")/
+
+      .address__inner__kana
+        .address__inner__kana__top
+          %p.address__inner__kana__top--title お名前カナ
+          %p.address__inner__kana__top--required 必須
+        .address__inner__kana__form
+          %input(type="text" placeholder="例) ヤマダ")/
+          %input(type="text" placeholder="例) アヤ")/
+
+      .address__inner__ZipCode
+        .address__inner__ZipCode__top
+          %p.address__inner__ZipCode__top--title 郵便番号
+          %p.address__inner__ZipCode__top--required 必須
+        .address__inner__ZipCode__form
+          %input(type="text" placeholder="例) 123-4567")/
+
+      .address__inner__prefectures
+        .address__inner__prefectures__top
+          %p.address__inner__prefectures__top--title 都道府県
+          %p.address__inner__prefectures__top--required 必須
+        .address__inner__prefectures__form
+          %input(type="text" placeholder="例) 福岡県")/
+      
+      .address__inner__city
+        .address__inner__city__top
+          %p.address__inner__city__top--title 市区町村
+          %p.address__inner__city__top--required 必須
+        .address__inner__city__form
+          %input(type="text" placeholder="例) 横浜市緑区")/
+      
+      .address__inner__BlockNumber
+        .address__inner__BlockNumber__top
+          %p.address__inner__BlockNumber__top--title 番地
+          %p.address__inner__BlockNumber__top--required 必須
+        .address__inner__BlockNumber__form
+          %input(type="text" placeholder="例) 青山1-1-1")/
+      
+      .address__inner__apartment
+        .address__inner__apartment__top
+          %p 建物名
+          %p.address__inner__apartment__top--any 任意
+        .address__inner__apartment__form
+          %input(type="text" placeholder="例) 柳ビル103")/
+      
+      .address__inner__btn 変更する
+      
+      
+        
+    


### PR DESCRIPTION
# what
住所登録画面の作成
ユーザー登録機能を実装後ルーティングの設定を行うため、
サーバー上では画面を確認できません
※スクショを貼っていますのでご確認ください

# why
住所登録のためには入力画面が必要であるため

![image](https://user-images.githubusercontent.com/61253138/85662803-4f2ed980-b6f3-11ea-9edb-a091eb48ccf2.png)
