### PR TITLE
購入確認画面からしか購入できないようにする

### DIFF
--- a/app/controllers/deals_controller.rb
+++ b/app/controllers/deals_controller.rb
@@ -1,6 +1,7 @@
 class DealsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_item, :set_card, :confirmation  
+  before_action :set_item, :set_card, :confirmation 
+  before_action :show, only: [:pay]
 
   require "payjp"
 


### PR DESCRIPTION
# what
購入確認画面からしか購入できないようにする

# why
意図しない操作を防ぐため