### PR TITLE
エラーハンドリングの修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,13 +37,36 @@ class ItemsController < ApplicationController
   end
 
   def update
-    if item_params[:category_id] == "---"
-      render :edit
-    elsif @item.update(item_params)
+    @category = @item.category_id
+    if @item.update(item_params) 
       redirect_to item_path
-    else
+    elsif item_params[:images_attributes] == ""
+      flash.now[:alert] = '変更できませんでした 【画像を１枚以上入れてください】'
+      render :edit
+    else item_params[:category_id].blank?
+      flash.now[:alert] = '変更できませんでした 【カテゴリーを選択してください】'
+      @item.category_id = @category
       render :edit
     end
+
+    # パターン②
+    # if item_params[:images_attributes].nil?
+    #   flash.now[:alert] = '更新できませんでした 【画像を１枚以上入れてください】'
+    #   render :edit
+    # elsif item_params[:category_id] == "---"
+    #   render :edit
+    # else @item.update(item_params)
+    #   redirect_to item_path
+    # end
+
+    # パターン①
+    # if item_params[:category_id] == "---"
+    #   render :edit
+    # elsif @item.update(item_params)
+    #   redirect_to item_path
+    # else
+    #   render :edit
+    # end
   end
 
   def destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,6 +12,8 @@ class Item < ApplicationRecord
   validates :delivery_regions, presence: {message: "選択してください"}
   validates :shipping_schedule, presence: {message: "選択してください"}
   validates :price, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "300以上9999999以下で入力して下さい"}
+  validates :images, length: {minimum: 1}
+  validates :category_id, presence: true
 
   enum condition: {
     "新品、未使用": 1,

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -35,7 +35,7 @@
                   %td
                     = link_to "#" do
                       = @parent.name
-                    - if @parent.id != @children.id
+                    - if @parent.id != @children&.id
                       = link_to "#" do 
                         = ">" + @children.name 
                     = link_to "#" do
@@ -97,8 +97,4 @@
         = image_tag 'icon/google-play-badge.png', alt: "画像１", class: "LinkIcon abtn"
       = link_to "#" do
         = image_tag 'icon/google-play-badge.png', alt: "画像１", class: "LinkIcon gbtn"
-  .exhibitionBtn
-    = link_to new_item_path do
-      %span.exhibitionBtn__text 出品
-      = image_tag 'icon/icon_camera.png', alt: "画像１", class: "exhibitionBtn__icon"
 = render "layouts/footer-main"


### PR DESCRIPTION
### What
商品編集のエラーハンドリング
①画像が0枚の場合は、変更することができないようにする。
②カテゴリーの孫カテゴリーが選択されていない場合は、変更できないようにする。

### Why
上記の状態で変更ができるようにすると、商品データに不具合が起きて、商品詳細ページにアクセスできなくなるため。