### PR TITLE
商品詳細ページの変更削除ボタンの修正

### DIFF
--- a/app/assets/stylesheets/modules/_show.scss
+++ b/app/assets/stylesheets/modules/_show.scss
@@ -148,40 +148,42 @@ td {
 
 .item {
   &__edit {
-    width: 100%;
-    height: 48px;
-    font-size: 18px;
-    font-weight: bold;
-    text-align: center;
-    line-height: 48px;
-    background-color: #3ccace;
-    border-radius: 4px;
     margin-top: 30px;
-    cursor: pointer;
     a {
+      display: inline-block;
+      width: 100%;
+      height: 48px;
+      font-size: 18px;
+      font-weight: bold;
+      text-align: center;
+      line-height: 48px;
+      background-color: #3ccace;
+      border-radius: 4px;
+      cursor: pointer;
       color: #fff;
     }
   }
-  &__edit:hover {
+  &__edit a:hover {
     background-color: rgb(172, 172, 172);
   }
 
   &__delete {
-    width: 100%;
-    height: 48px;
-    font-size: 18px;
-    font-weight: bold;
-    text-align: center;
-    line-height: 48px;
-    background-color: rgb(100, 100, 100);
-    border-radius: 4px;
     margin-top: 30px;
-    cursor: pointer;
     a {
+      display: inline-block;
+      width: 100%;
+      height: 48px;
+      font-size: 18px;
+      font-weight: bold;
+      text-align: center;
+      line-height: 48px;
+      background-color: rgb(100, 100, 100);
+      border-radius: 4px;
+      cursor: pointer;
       color: #fff;
     }
   }
-  &__delete:hover {
+  &__delete a:hover {
     background-color: rgb(172, 172, 172);
   }
 

--- a/app/views/users/_new_address.html.haml
+++ b/app/views/users/_new_address.html.haml
@@ -54,7 +54,7 @@
         .address__inner__apartment__form
           %input(type="text" placeholder="例) 柳ビル103")/
       
-      .address__inner__btn 変更する
+      .address__inner__btn 登録する
       
       
         


### PR DESCRIPTION
### What
商品詳細ページの変更削除ボタンの操作性がユーザーに使用しにくい仕様になっていたため。

### Why
商品詳細ページの変更削除ボタンが、a要素を押さなければページ移行しなかったため。